### PR TITLE
fix: InvalidCastException - indirect (boxed value) cast of int to double

### DIFF
--- a/Core/DefaultCulture.cs
+++ b/Core/DefaultCulture.cs
@@ -1,13 +1,25 @@
-﻿using System.Globalization;
+﻿using System.Configuration;
+using System.Globalization;
 
 namespace Knoema.Localization
 {
 	public static class DefaultCulture
 	{
-		private static CultureInfo _culture = new CultureInfo(1033);
+		private static CultureInfo _culture;
+		private const string DefaultCultureSettingName = "localizerDefaultCulture";
+		private static CultureInfo _cultureDefaultValue = new CultureInfo(1033);
+
 		public static CultureInfo Value
 		{
-			get { return _culture; }
+			get
+			{
+				if (_culture == null) 
+				{
+					string cultureName = ConfigurationManager.AppSettings[DefaultCultureSettingName];
+					_culture = cultureName != null ? CultureInfo.GetCultureInfo(cultureName) : _cultureDefaultValue;
+				}
+				return _culture;
+			}
 		}
 
 		public static bool IsDefault(this string name)

--- a/Core/Knoema.Localization.Core.csproj
+++ b/Core/Knoema.Localization.Core.csproj
@@ -44,6 +44,7 @@
       <HintPath>..\packages\AjaxMin.4.60.4609.17023\lib\net20\AjaxMin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />

--- a/Mvc/Mvc/ValidationLocalizer.cs
+++ b/Mvc/Mvc/ValidationLocalizer.cs
@@ -61,7 +61,9 @@ namespace Knoema.Localization.Mvc
 			if (attribute is RangeAttribute)
 			{
 				var attr = (RangeAttribute)attribute;
-				result = new RangeAttribute((double)attr.Minimum, (double)attr.Maximum);
+				result = (attr.Minimum is double)
+					?  new RangeAttribute((double)attr.Minimum, (double)attr.Maximum)
+					:  new RangeAttribute((int)attr.Minimum, (int)attr.Maximum);
 			}
 
 			if (attribute is RegularExpressionAttribute)


### PR DESCRIPTION
 RangeAttribute is not so simple thing: there are 3 constructors - 1 for ints, 1 for doubles and 1 for anything that has TypeConverter for and is IComparable. Anything that one puts inside is boxed into 2 objects. Though its fully acceptable to make a cast like this:
`(double)1`
another one fragment
`(double)((object)1)` 
will result in InvalidCastException - and its exactly what happens in case of int-initialized RangeAttribute "cloning".