### PR TITLE
fix: InvalidCastException - boxed value cast of int to double

### DIFF
--- a/Mvc/Mvc/ValidationLocalizer.cs
+++ b/Mvc/Mvc/ValidationLocalizer.cs
@@ -61,7 +61,9 @@ namespace Knoema.Localization.Mvc
 			if (attribute is RangeAttribute)
 			{
 				var attr = (RangeAttribute)attribute;
-				result = new RangeAttribute((double)attr.Minimum, (double)attr.Maximum);
+				result = (attr.Minimum is double)
+					?  new RangeAttribute((double)attr.Minimum, (double)attr.Maximum)
+					:  new RangeAttribute((int)attr.Minimum, (int)attr.Maximum);
 			}
 
 			if (attribute is RegularExpressionAttribute)


### PR DESCRIPTION
 RangeAttribute is not so simple thing: there are 3 constructors - 1 for ints, 1 for doubles and 1 for anything that has TypeConverter for and is IComparable. Anything that one puts inside is boxed into 2 objects. Though its fully acceptable to make a cast like this:
`(double)1`
another one fragment
`(double)((object)1)` 
will result in InvalidCastException - and its exactly what happens in case of int-initialized RangeAttribute "cloning".