### PR TITLE
feature: default culture option in AppSettings

### DIFF
--- a/Core/DefaultCulture.cs
+++ b/Core/DefaultCulture.cs
@@ -1,13 +1,25 @@
-﻿using System.Globalization;
+﻿using System.Configuration;
+using System.Globalization;
 
 namespace Knoema.Localization
 {
 	public static class DefaultCulture
 	{
-		private static CultureInfo _culture = new CultureInfo(1033);
+		private static CultureInfo _culture;
+		private const string DefaultCultureSettingName = "localizerDefaultCulture";
+		private static CultureInfo _cultureDefaultValue = new CultureInfo(1033);
+
 		public static CultureInfo Value
 		{
-			get { return _culture; }
+			get
+			{
+				if (_culture == null) 
+				{
+					string cultureName = ConfigurationManager.AppSettings[DefaultCultureSettingName];
+					_culture = cultureName != null ? CultureInfo.GetCultureInfo(cultureName) : _cultureDefaultValue;
+				}
+				return _culture;
+			}
 		}
 
 		public static bool IsDefault(this string name)

--- a/Core/Knoema.Localization.Core.csproj
+++ b/Core/Knoema.Localization.Core.csproj
@@ -44,6 +44,7 @@
       <HintPath>..\packages\AjaxMin.4.60.4609.17023\lib\net20\AjaxMin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />


### PR DESCRIPTION
  DefaultCulture class lacked the ability to set its value - it was hardwritten value of 1033 (en-US locale), though in many cases for other (not from Knoema :smile: ) developers keys (text) for localization may be originally presented in other language. 
 Now DefaultCulture has its default value set to en-US but it **_can_** be configured via `<appSettings>` in the following way inside of web.config:

```
<appSettings>
   ...
   <add key="localizerDefaultCulture" value="ru-RU"/>
</appSettings>
```

Changes description: 
- Knoema.Localization.Core.csproj :added reference to System.Configuration
- DefaultCulture.cs: changed the implementation of DefaultCulture.Value  (no need for multithreaded sync - its static context and immutability during app lifecycle).
